### PR TITLE
Fix bugs in Haskell->Rust and Rust->Haskell articles

### DIFF
--- a/_posts/2016-10-01-haskell-rust.md
+++ b/_posts/2016-10-01-haskell-rust.md
@@ -469,3 +469,6 @@ take some time to get right but making this a seamless experience for
 users would be great. I think Rust and Haskell compliment
 each other well and making it easy to do that will be a boon to both
 communities.
+
+Thanks to [Caleb Jones](https://github.com/porglezomp) for making some minor
+corrections to this article.

--- a/_posts/2016-10-01-haskell-rust.md
+++ b/_posts/2016-10-01-haskell-rust.md
@@ -169,7 +169,7 @@ Now we're going to write our printing function:
 pub extern fn print_string(x: *const c_char) {
   unsafe {
     let cstring = CStr::from_ptr(x);
-    if let Ok(input) = x.to_str() {
+    if let Ok(input) = cstring.to_str() {
       println!("{}", input);
     } else {
       panic!("Unable to print input");

--- a/_posts/2016-10-15-rust-haskell.md
+++ b/_posts/2016-10-15-rust-haskell.md
@@ -190,6 +190,8 @@ to act as our intermediary for Rust and Haskell. Open up a file in this
 directory called `inter.c` and place the following in it:
 
 ```c
+#include <HsFFI.h>
+
 void init(void) {
   static char *argv[] = { "libhs.so", 0 }, **argv_ = argv;
   static int argc = 1;
@@ -210,12 +212,9 @@ ghc -shared -o libinter.so inter.c libhs.so -fPIC
 
 This creates a shared library `inter.so` that we can use that's linked with
 `libhs.so` using Position Independent Code. We compile it using ghc as a C
-compiler so that it can locate all the haskell runtime libraries. Now you'll get
-warnings about implicit declarations. Don't worry about them. Remember in
-`wrapper.c` how we imported HsFFI? Well it's located in `libhs.so` and it
-contains the functions `hs_init` and `hs_exit` that we want to use! `inter.c` is
-just used as a wrapper to make starting and stopping the Haskell runtime in Rust
-easier to do. Alright now let's write some Rust!
+compiler so that it can locate all the haskell runtime libraries. `inter.c` is
+just used as a wrapper around `hs_init` and `hs_exit` to make it easier to start
+and stop the Haskell runtime in Rust. Alright now let's write some Rust!
 
 ### Rust
 First up open up Cargo.toml and change it to have a build file and to
@@ -295,7 +294,7 @@ to avoid this problem:
 build: hs cargo
 
 hs:
-	@(cd hs2rs && stack build && ghc -shared -o libinter.so inter.c libhs.so -fPIC -Wno-implicit)
+	@(cd hs2rs && stack build && ghc -shared -o libinter.so inter.c libhs.so -fPIC)
 
 cargo:
 	@cargo build

--- a/_posts/2016-10-15-rust-haskell.md
+++ b/_posts/2016-10-15-rust-haskell.md
@@ -342,3 +342,6 @@ or vice versa and allowing Haskell to have a type safe fast language
 when speed truly is critical.
 
 If you're interested on bridging that gap as well let me know!
+
+Thanks to [Caleb Jones](https://github.com/porglezomp) for making some
+corrections to this article.

--- a/_posts/2016-10-15-rust-haskell.md
+++ b/_posts/2016-10-15-rust-haskell.md
@@ -22,7 +22,6 @@ This articles assumes you have the following installed:
 - cargo
 - stack
 - GHC 8.0.1
-- gcc
 - make
 
 ### Setting up the project
@@ -160,7 +159,7 @@ Also look at the flags used:
 
 - `-dynamic` tells GHC that we want a dynamic library
 - `-fPIC` is also necessary because of the need for Position Independent Code
-- `-lHSrst-ghc8.0.1` is telling GHC to link in the rst library which we
+- `-lHSrts-ghc8.0.1` is telling GHC to link in the rts library which we
   need for our code to work in other places. It's tied to the version of
   the compiler you use. Just change the last few numbers to the version
   you're using for this to work. However, at the time of writing
@@ -206,16 +205,17 @@ void fin(void) {
 Now run the following:
 
 ```bash
-gcc -shared -o libinter.so inter.c libhs.so -fPIC
+ghc -shared -o libinter.so inter.c libhs.so -fPIC
 ```
 
 This creates a shared library `inter.so` that we can use that's linked with
-`libhs.so` using Position Independent Code. Now you'll get warnings
-about implicit declarations. Don't worry about them. Remember in
-`wrapper.c` how we imported HsFFI? Well it's located in `libhs.so` and
-it contains the functions `hs_init` and `hs_exit` that we want to use!
-`inter.c` is just used as a wrapper to make starting and stopping the
-Haskell runtime in Rust easier to do. Alright now let's write some Rust!
+`libhs.so` using Position Independent Code. We compile it using ghc as a C
+compiler so that it can locate all the haskell runtime libraries. Now you'll get
+warnings about implicit declarations. Don't worry about them. Remember in
+`wrapper.c` how we imported HsFFI? Well it's located in `libhs.so` and it
+contains the functions `hs_init` and `hs_exit` that we want to use! `inter.c` is
+just used as a wrapper to make starting and stopping the Haskell runtime in Rust
+easier to do. Alright now let's write some Rust!
 
 ### Rust
 First up open up Cargo.toml and change it to have a build file and to
@@ -295,7 +295,7 @@ to avoid this problem:
 build: hs cargo
 
 hs:
-	@(cd hs2rs && stack build && gcc -shared -o libinter.so inter.c libhs.so -fPIC -Wno-implicit)
+	@(cd hs2rs && stack build && ghc -shared -o libinter.so inter.c libhs.so -fPIC -Wno-implicit)
 
 cargo:
 	@cargo build


### PR DESCRIPTION
I ran into a few bugs/typos that made it impossible to directly follow
along with the articles. This fixes those for other readers in the
future.

The biggest change is compiling the C code with GHC instead of GCC,
since that seems to be the recommended practice for Haskell, and it's
what made it start working for me.
